### PR TITLE
Clarify multiple VA to PA mapping

### DIFF
--- a/src/mte_tag.adoc
+++ b/src/mte_tag.adoc
@@ -218,10 +218,11 @@ splitted stores.
   A memory access (load or store) to some virtual address `va` can not bypass
   the older store initiated by `settag/setinvtag rs1=va`.
 
-  This specification defines tag as the entitiy attached to virtual addresses.  
-  It is software's responsibility to ensure that the tags are appropriately set
-  on the virtual addresses even though some of them map to the same physical 
-  address(es).
+  This specification defines tag as the entity associated to virtual addresses.
+  In case of aliasing (multiple virtual addresses map to same physical address), 
+  it is software's responsibility to ensure that the tags are set according to 
+  software's need for respective virtual address prior to memory accesses via 
+  aliased virtual address.
 
 * Exceptions
 

--- a/src/mte_tag.adoc
+++ b/src/mte_tag.adoc
@@ -218,6 +218,11 @@ splitted stores.
   A memory access (load or store) to some virtual address `va` can not bypass
   the older store initiated by `settag/setinvtag rs1=va`.
 
+  This specification defines tag as the entitiy attached to virtual addresses.  
+  It is software's responsibility to ensure that the tags are appropriately set
+  on the virtual addresses even though some of them map to the same physical 
+  address(es).
+
 * Exceptions
 
   `settag/setinvtag` can raise store page fault or access fault depending on

--- a/src/mte_tag.adoc
+++ b/src/mte_tag.adoc
@@ -219,9 +219,9 @@ splitted stores.
   the older store initiated by `settag/setinvtag rs1=va`.
 
   This specification defines tag as the entity associated to virtual addresses.
-  In case of aliasing (multiple virtual addresses map to same physical address), 
-  it is software's responsibility to ensure that the tags are set according to 
-  software's need for respective virtual address prior to memory accesses via 
+  In case of aliasing (multiple virtual addresses map to same physical address),
+  it is software's responsibility to ensure that the tags are set according to
+  software's need for respective virtual address prior to memory accesses via
   aliased virtual address.
 
 * Exceptions


### PR DESCRIPTION
Added note on software's responsibility because tags are defined on VA.