### PR TITLE
m-mode tagging: Standardize support for m-mode tagging

### DIFF
--- a/src/mte_tag.adoc
+++ b/src/mte_tag.adoc
@@ -376,10 +376,7 @@ annotate pointer with `pointer_tag`. Something along the below listing.
 [[MEMTAG_CSR_CTRL]]
 === CSR bits for memory tagging
 
-In M-mode, enable for memory tagging and subsequent behavior of Zimte
-instructions is implementation specific. Although if an implementation is not
-enabling memory tagging for M-mode, it must follow zimop behavior for Zimte
-instructions in M-mode.
+In M-mode, enable for memory tagging is controlled via `mseccfg` CSR.
 
 Enablement for privilege modes less than M-mode is controlled through
 `__x__envcfg` CSR. Zimte adds two bits termed as `MTE_MODE` to `__x__envcfg`
@@ -417,6 +414,35 @@ configuration
   implementation supports both `pointer_tag` widths.
 
   If xMTE_MODE == 0b00 then xMTE_MODE.MT_ASYNC becomes WPRI
+
+==== Machine Security Configuration Register(`mseccfg`)
+
+.Machine security configuration register(`mseccfg`)
+[wavedrom, ,svg]
+....
+{reg: [
+  {bits:  1, name: 'MML'},
+  {bits:  1, name: 'MMWP'},
+  {bits:  1, name: 'RLB'},
+  {bits:  5, name: 'WPRI'},
+  {bits:  1, name: 'USEED'},
+  {bits:  1, name: 'SSEED'},
+  {bits:  1, name: 'MLPE'},
+  {bits: 21, name: 'WPRI'},
+  {bits:  2, name: 'PMM'},
+  {bits:  2, name: 'MTE_MODE'},
+  {bits:  1, name: 'MT_ASYNC'},
+  {bits:  1, name: 'EN_TAG_ELIDE'},
+  {bits: 26, name: 'WPRI'},
+], config:{lanes: 4, hspace:1024}}
+....
+
+The Zimte extension adds the `MTE_MODE` field (bit 34:2) to `mseccfg`. When the
+`MTE_MODE` field is set to `0b10` or `0b11`, memory tagging is enabled for
+M-mode.
+
+When `MTE_MODE` is `0b00`, the following rules apply to M-mode:
+* Zimte instructions will revert to their behavior as defined by Zimop.
 
 ==== Machine Environment Configuration Register (`menvcfg`)
 

--- a/src/mte_vatag.adoc
+++ b/src/mte_vatag.adoc
@@ -54,10 +54,9 @@ requires read, modify (masking and shifting of bits) and store back to
 [[VIRT_TAG_BASE_CSR]]
 === Tag table base address CSRs
 
-Tag storage base address (`__x__VITT_BASE`) for M-mode can be be implementation
-specific. VITT base virtual address for privilege mode less than M-mode is
-defined using privileged CSRs. Tag table base address must be 4K aligned.
-Following table list the privileged CSRs.
+Tag storage base virtual address (`__x__VITT_BASE`) is defined using privileged
+CSRs. Tag table base address must be 4K aligned. Following table list the
+privileged CSRs.
 
 .Privileged tag base address CSRs
 [width=100%]
@@ -67,7 +66,7 @@ Following table list the privileged CSRs.
 |  U             | `svittu`
 |  S / HS        | `svitts`
 |  VS            | `vsvitts`
-|  M             | `Impl. defined`
+|  M             | `mvitt`
 |===
 
 [[TAG_MEM_PROTECTION]]
@@ -88,7 +87,7 @@ spanning VITT range. VITT range is defined as below
 |Privilege level | LOWEST_VADDR_CURR_PRIV | HIGHEST_VADDR_CURR_PRIV
 |  U             | 0                      | 2 ^ (VADDR_BITS) - 1
 |  S / HS / VS   | 2 ^ (VADDR_BITS)       | 2 ^ (VADDR_BITS) OR (2 ^ (VADDR_BITS) - 1)
-|  M             | `Impl. defined`        | `Impl. defined`
+|  M             | 0                      | `Impl. defined`
 |===
 
 VADDR_BITS is virtual addressing bits. VADDR_BITS can be 39, 48 or 57
@@ -98,3 +97,6 @@ depending on Sv39, Sv48 or Sv57 virtual addressing mode in `satp` CSR.
 with user address space spanning from zero to maxium positive address while
 supervisor address space spanning from minimum negative value to maximum
 negative value.
+
+Lowest virtual address in M-mode is defined to be 0 and highest virtual address
+for M-mode is implementation dependent.


### PR DESCRIPTION
Recent discussions in TG echoed that support for m-mode tagging should be standardized instead of leaving the enabling mechanism to be impl. dependent. This patch defines the enabling mechanism to be defined via `mseccfg` CSR and adds a CSR for holding base address for tag table. Maximum virtual address of M-mode is left impl. defined because priv spec doesn't define any standard mechanism to discover maximum addressable physical address on platform.