### PR TITLE
Adding requirement to fault on settag to normal data

### DIFF
--- a/src/mte_vatag.adoc
+++ b/src/mte_vatag.adoc
@@ -73,7 +73,9 @@ privileged CSRs.
 === Protection of tag storage
 
 Hart must raise access faults on regular loads and stores to virtual addresses
-spanning VITT range. VITT range is defined as below
+spanning VITT range. Hart must also raise access fault on `settag` and `setinvtag`
+instructions to the VITT
+range. VITT range is defined as below
 
   tag_memory_region_start = mc_tag_va(LOWEST_VADDR_CURR_PRIV)
   tag_memory_region_end = mc_tag_va(HIGHEST_VADDR_CURR_PRIV)

--- a/src/mte_vatag.adoc
+++ b/src/mte_vatag.adoc
@@ -74,7 +74,7 @@ privileged CSRs.
 
 Hart must raise access faults on regular loads and stores to virtual addresses
 spanning VITT range. Hart must also raise access fault on `settag` and `setinvtag`
-instructions to the VITT
+instructions to the non-VITT
 range. VITT range is defined as below
 
   tag_memory_region_start = mc_tag_va(LOWEST_VADDR_CURR_PRIV)


### PR DESCRIPTION
Adding this requirement separates the tag pages and the normal pages more thoroughly. This would eliminate some checks by harts, i.e. those needed for settag to see if there is any in-flight stores to the same address.