### PR TITLE
Clarify CMO operations under MTE (#6)

### DIFF
--- a/src/mte_tag.adoc
+++ b/src/mte_tag.adoc
@@ -315,6 +315,13 @@ can choose to enable on per-page basis. Furthermore, this allows software to
 enable memory tagging only for heap.
 ====
 
+[NOTE]
+====
+Cache Management Operations (CMOs) must respect and take into account memory tagging extension. Otherwise, serious security problems can appear, including:
+
+* CBO.ZERO may work as a STORE operation. If memory tagging is not respected, it would be possible to write to memory bypassing the tag enforcement.
+====
+
 [[TAGCHECK_ELIDE]]
 === Per-pointer tag check elision
 

--- a/src/mte_tag.adoc
+++ b/src/mte_tag.adoc
@@ -339,9 +339,10 @@ kept as reserved for such page table encodings.
 
 [NOTE]
 ====
-Cache Management Operations (CMOs) must respect and take into account memory tagging extension. Otherwise, serious security problems can appear, including:
-
-* CBO.ZERO may work as a STORE operation. If memory tagging is not respected, it would be possible to write to memory bypassing the tag enforcement.
+The memory tagging extension is based on the Pointer Masking extension and
+follows the same rules for memory access. For further information, see section
+24.2.6 of the privilege specification: Memory Accesses Subject to Pointer
+Masking.
 ====
 
 [[TAGCHECK_ELIDE]]


### PR DESCRIPTION
Clarify that MTE is applicable to CMO (especially CBO.ZERO operation). This would also address #6 