### PR TITLE
src/mte_vatag: Split Svatag and add dependency on Svukte

### DIFF
--- a/src/mte_vatag.adoc
+++ b/src/mte_vatag.adoc
@@ -1,14 +1,15 @@
 [[virtualtag]]
-== Virtually indexed tag storage (Svatag)
+== Virtually indexed tag storage (Svatag and Smvatag)
 
-Svatag extension defines that tag storage for memory chunks (`mc`) as defined
-by Zimte (see <<tagging>>) extension is in virtual address
-space of execution environment. Tag storage can be viewed as a large array
-(hereafter referred to as virtually indexed tag table or VITT) of the tags
-(`mc_tag`) with each tag width = `mc_tag_width` (see
-<<tagging>> for `mc_tag` and `mc_tag_width`). Base virtual
-address of this large array is determined differently depending on privilege
-mode (see <<VIRT_TAG_BASE_CSR>>) and hereafter referred as `__x__VITT_BASE`.
+Svatag (for S/HS/VS/U/VU) and Smvatag (for M) extensions defines that tag
+storage and tag lookups for memory chunks (`mc`) as defined by Zimte (see
+<<tagging>>) extension is in virtual address space of execution environment.
+Tag storage can be viewed as a large array (hereafter referred to as
+virtually indexed tag table or VITT) of the tags (`mc_tag`) with each tag
+width = `mc_tag_width` (see <<tagging>> for `mc_tag` and `mc_tag_width`).
+Base virtual address of this large array is determined differently depending
+on privilege mode (see <<VIRT_TAG_BASE_CSR>>) and hereafter referred as
+`__x__VITT_BASE`.
 
 [[VIRT_TAG_LOOKUP]]
 === Tag look up in virtually indexed tag table
@@ -69,6 +70,9 @@ privileged CSRs.
 |  M             | `mvitt`
 |===
 
+`Svatag` defines the `svittu`, `svitts` and `vsvitts` CSRs while `Smvatag`
+defines `mvitt`.
+
 [[TAG_MEM_PROTECTION]]
 === Protection of tag storage
 
@@ -93,10 +97,10 @@ spanning VITT range. VITT range is defined as below
 VADDR_BITS is virtual addressing bits. VADDR_BITS can be 39, 48 or 57
 depending on Sv39, Sv48 or Sv57 virtual addressing mode in `satp` CSR.
 
-`Svatag` assumes an even split in address space between user and supervisor
-with user address space spanning from zero to maxium positive address while
-supervisor address space spanning from minimum negative value to maximum
-negative value.
+`Svatag` depends on `Svukte` extension and thus assumes an even split in
+address space between user and supervisor with user address space spanning
+from zero to maxium positive address while supervisor address space spanning
+from minimum negative value to maximum negative value.
 
 Lowest virtual address in M-mode is defined to be 0 and highest virtual address
 for M-mode is implementation dependent.


### PR DESCRIPTION
Svatag defines tag storage and lookup for U/VU/S/HS/VS mode while Smvatag defines for M-mode.
Svatag depends on virtual memory and assumes even split of memory range between user and kernel, thus it is made dependent on Svukte.