### PR TITLE
contribs: Listing contributors names

### DIFF
--- a/src/contributors.adoc
+++ b/src/contributors.adoc
@@ -1,5 +1,7 @@
 == Contributors
 
-This RISC-V specification has been contributed to directly or indirectly by:
+This RISC-V specification has been contributed to directly or indirectly by (in alphabetical order):
 
 [%hardbreaks]
+
+Adam Zabrocki, Alvin Che-Chia Chang, Andrew Waterman, Brendan Sweeney, Christoph Müllner, David Weaver, Deepak Gupta, Earl Killian, Florian Mayer, Luís Fiolhais, Martin Maas, Nick Kossifidis, Radim Krčmář, Ravi Sahita, Robbin Ehn, Samuel Holland, Siqi Zhao, Thurston Dang, Vedvyas Shanbhogue


### PR DESCRIPTION
Adding list of contributors (as good as I could remember) who contributed to spec through mailing list discussions, meeting discussions, PRs or any other way directly or indirectly.
If I missed someone's name, let me know.