### PR TITLE
gentag rs1 = x0 and impact on mte instruction behavior due to MTAG for code pages

### DIFF
--- a/src/mte_intro.adoc
+++ b/src/mte_intro.adoc
@@ -65,7 +65,10 @@ using `free` or stack locals are out of scope after a function has returned)
 then software can change assigned `tag` in tag storage. On a memory access (i.e
 pointer dereference), `tag` in pointer is checked against stored `tag` for that
 memory and if tags do not match then it is due to a memory safety bug in
-program.
+program. For rest of the document such memory accesses shall be referred to as
+`checked memory accesses` or `checked loads and stores`. Memory accesses or loads
+and stores not subject to tag checks shall be referred to as `unchecked memory
+accesses` or `unchecked loads and stores`.
 
 Existing software mechanisms using compiler assisted software instrumentation
 and runtime support exist (address sanitizer aka ASan) cite:[ASAN]. However

--- a/src/mte_tag.adoc
+++ b/src/mte_tag.adoc
@@ -58,9 +58,9 @@ Following are the instructions to place `pointer_tag` in the source register
 ==== Generate a tag - gentag rd, rs1
 
 If memory tagging is enabled in the current execution environment (see
-<<MEM_TAG_EN>>), hart clears `rd`, generates a `pointer_tag` value with at
-least 1-bit different from `rs1[XLEN:XLEN-pointer_tag_width+1]` and places the result
-back in `rd[XLEN:XLEN-pointer_tag_width+1]`.
+<<MEM_TAG_EN>>) and code page has `MTAG` bit clear in the page table entry (see
+<<TAGGED_PAGE>>), hart clears `rd`, generates a `pointer_tag` value and places
+the result in `rd[XLEN:XLEN-pointer_tag_width+1]`.
 
 [wavedrom, ,svg]
 ....
@@ -68,7 +68,7 @@ back in `rd[XLEN:XLEN-pointer_tag_width+1]`.
   {bits:  7, name: 'opcode', attr:'SYSTEM'},
   {bits:  5, name: 'rd', attr:['pointer_tag']},
   {bits:  3, name: 'funct3', attr:['100']},
-  {bits:  5, name: 'rs1', attr:['tagged_pointer']},
+  {bits:  5, name: 'rs1', attr:['00000']},
   {bits:  4, name: 'tag_imm4', attr:['0000']},
   {bits:  1, name: '0', attr:['0']},
   {bits:  7, name: '1000011', attr:['gentag']},

--- a/src/mte_tag.adoc
+++ b/src/mte_tag.adoc
@@ -62,6 +62,11 @@ If memory tagging is enabled in the current execution environment (see
 <<TAGGED_PAGE>>), hart clears `rd`, generates a `pointer_tag` value and places
 the result in `rd[XLEN:XLEN-pointer_tag_width+1]`.
 
+If memory tagging is disabled in the current execution environment (see
+<<MEM_TAG_EN>>) or MTAG=1 (see <<TAGGED_PAGE>>) in the page table entry for
+code page, then `gentag` instruction falls back to zimop behavior and zeroes
+destination register.
+
 [wavedrom, ,svg]
 ....
 {reg: [
@@ -82,15 +87,17 @@ See Appendix for example how this can be used by codegen.
 
 ==== Arithmetics on pointer tag - addtag rd, rs1, #tag_imm4
 
-`addtag rd, rs1` is a pseudo for `gentag rd, rs1` with tag_imm4 != 0. If memory
-tagging is enabled in the current execution environment (see <<MEM_TAG_EN>>),
-`addtag rd, rs1` instruction performs addition of `pointer_tag` specified in
-`rs1[XLEN:XLEN-pointer_tag_width+1]` with the unsigned value `tag_imm4` shifted
-left by `XLEN - pointer_tag_width` bits and places incremented `pointer_tag`
-value in `rd[XLEN:XLEN-pointer_tag_width+1]`.
-If memory tagging is disabled in the current execution environment,
-then `addtag` instruction falls back to zimop behavior
-and zeroes destination register.
+If memory tagging is enabled in the current execution environment (see
+<<MEM_TAG_EN>>) and code page has `MTAG` bit clear in the page table entry
+(see <<TAGGED_PAGE>>), `addtag rd, rs1` instruction performs addition of
+`pointer_tag` specified in `rs1[XLEN:XLEN-pointer_tag_width+1]` with the
+unsigned value `tag_imm4` shifted left by `XLEN - pointer_tag_width` bits and
+places incremented `pointer_tag` value in `rd[XLEN:XLEN-pointer_tag_width+1]`.
+
+If memory tagging is disabled in the current execution environment (see
+<<MEM_TAG_EN>>) or MTAG=1 (see <<TAGGED_PAGE>>) in the page table entry for
+code page, then `addtag` instruction falls back to zimop behavior and zeroes
+destination register.
 
 [wavedrom, ,svg]
 ....
@@ -127,9 +134,6 @@ immediate (#chunk_count) in the instruction. This instruction is encoded using
 `MOP.RR.0` from zimop extension. Immediate encodings in #chunk_count are zero
 based and thus #chunk_count = 0 means first chunk and #chunk_count = 15 means
 16th chunk.
-If memory tagging is disabled in the current execution environment,
-then `settag` instruction falls back to zimop behavior
-and zeroes x0, which is a no-op.
 
 [NOTE]
 ====
@@ -146,10 +150,16 @@ required by software, it can be added.
 ==== Store tag(s) for memory chunk(s): settag rs1, #chunk_count
 
 If memory tagging is enabled in the current execution environment (see
-<<MEM_TAG_EN>>), `settag` instruction creates a `mc_tag` =
+<<MEM_TAG_EN>>) and code page has `MTAG` bit clear in the page table entry
+(see <<TAGGED_PAGE>>), `settag` instruction creates a `mc_tag` =
 `rs1[XLEN:XLEN-pointer_tag_width+1]` and stores `mc_tag(s)` for consecutive
 memory chunks encoded by `chunk_count` starting with the first memory chunk
 calculated from virtual address specified in `rs1`.
+
+If memory tagging is disabled in the current execution environment (see
+<<MEM_TAG_EN>>) or MTAG=1 (see <<TAGGED_PAGE>>) in the page table entry for
+code page, then `settag` instruction falls back to zimop behavior and zeroes
+x0, which is a no-op.
 
 [wavedrom, ,svg]
 ....

--- a/src/mte_tag.adoc
+++ b/src/mte_tag.adoc
@@ -222,8 +222,9 @@ page (see <<TAGGED_PAGE>>) in the first stage page table are subject to memory
 tagging checks.
 
 ==== tag checks
-Once a load/store is determined to be subject to memory tagging checks,
-following further checks are performed
+Once a load/store is determined (after paging bit checks and *envcfg control
+bit checks) to be subject to memory tagging checks, following further checks
+are performed
 
 * All stack pointer (sp/x2) relative accesses are not checked for tags (see
   notes).
@@ -259,25 +260,39 @@ Note that tag check violations on loads must always be reported synchronously.
 [[TAGGED_PAGE]]
 === Tag checks on page basis
 
-Memory tagging extension extends first stage page table by introducing a new
-leaf PTE bit (bit position TBD) termed as `MTAG`. If an implementation
-implements memory tagging extension then `PTE.MTAG` is no more a reserved bit,
-irrespective of memory tagging is enabled or not for current execution
-environment.
+`Zimte` introduces `memory tag` (`MTAG`) bit in first stage page table which if
+set in page table entry and memory tagging is enabled from *envcfg CSR,
+following rules apply:
 
-If memory tagging is enabled for the current execution environment (see
-<<MEM_TAG_EN>>) and PTE.MTAG = 1, then the page is considered a tagged page and
-load / stores to such a page are subject to tag checks (see <<TAG_CHECKS>>).
-Underlying tagged page must be idempotent memory else tag look up for referenced
-virtual memory will result in load access-fault exception.
+ 1) tag checks are enforced on load/stores to such pages. See <<TAG_CHECKS>>
+    for further checks. Underlying tagged page must be idempotent memory else
+    tag look up for referenced virtual memory will result in load access-fault
+    exception.
+
+ 2) fetched instructions from pages with `MTAG=1` do not generate checked loads
+    and stores. Additionally fetched `gentag`, `addtag` and `settag`
+    instructions from such code page fallback to zimop behavior.
+
+ 3) If both rule 2 and rule 1 are applying, rule 2 takes precedence.
+
+ 4) An instruction crossing a page boundary with differing `MTAG` value,
+    common denominator of `MTAG=0` applies for such instruction.
+
+`MTAG` bit in page table entry remains a reserved bit if `XWR == 111` or
+`XWR == `010` and if set, will raise a page fault of original access type.
+
+If memory tagging is not enabled for the execution environment via *envcfg CSR,
+then `MTAG` bit in page table entry remains a reserved and if set will raise a
+page fault of original access type.
 
 [NOTE]
 ====
-A bit in page table entry allows software to enable memory tagging on per-page
-basis and thus can have several discontigous regions on which tagging can be
-enabled. Depending on complexity of program and memory allocator(s), software
-can choose to enable on per-page basis. Furthermore, this allows software to
-enable memory tagging only for heap.
+`MTAG` bit on data pages allows an software to opt into selected memory regions
+for checked loads and stores. Furthermore, `MTAG` bit on executable pages
+allows software to opt out certain code regions from being subject to checked
+loads and stores. From usability point of view, having loads and stores don't
+make sense for shadow stack pages or self modifying code. Thus `MTAG` bit is
+kept as reserved for such page table encodings.
 ====
 
 [[TAGCHECK_ELIDE]]


### PR DESCRIPTION
There is no point having `rs1` as argument for `gentag` instruction. Removing that.
Furthermore mte instructions fallback to zimop behavior if fetched from code page with MTAG=1