### PR TITLE
gentag takes rs1 = x0 and impact on mte instructions due to MTAG for code pages

### DIFF
--- a/src/mte_tag.adoc
+++ b/src/mte_tag.adoc
@@ -58,9 +58,9 @@ Following are the instructions to place `pointer_tag` in the source register
 ==== Generate a tag - gentag rd, rs1
 
 If memory tagging is enabled in the current execution environment (see
-<<MEM_TAG_EN>>), hart clears `rd`, generates a `pointer_tag` value with at
-least 1-bit different from `rs1[XLEN:XLEN-pointer_tag_width+1]` and places the result
-back in `rd[XLEN:XLEN-pointer_tag_width+1]`.
+<<MEM_TAG_EN>>) and code page has `MTAG` bit clear in the page table entry (see
+<<TAGGED_PAGE>>), hart clears `rd`, generates a `pointer_tag` value and places
+the result in `rd[XLEN:XLEN-pointer_tag_width+1]`.
 
 [wavedrom, ,svg]
 ....
@@ -68,7 +68,7 @@ back in `rd[XLEN:XLEN-pointer_tag_width+1]`.
   {bits:  7, name: 'opcode', attr:'SYSTEM'},
   {bits:  5, name: 'rd', attr:['pointer_tag']},
   {bits:  3, name: 'funct3', attr:['100']},
-  {bits:  5, name: 'rs1', attr:['tagged_pointer']},
+  {bits:  5, name: 'rs1', attr:['00000']},
   {bits:  4, name: 'tag_imm4', attr:['0000']},
   {bits:  1, name: '0', attr:['0']},
   {bits:  7, name: '1000011', attr:['gentag']},

--- a/src/mte_tag.adoc
+++ b/src/mte_tag.adoc
@@ -62,6 +62,11 @@ If memory tagging is enabled in the current execution environment (see
 <<TAGGED_PAGE>>), hart clears `rd`, generates a `pointer_tag` value and places
 the result in `rd[XLEN:XLEN-pointer_tag_width+1]`.
 
+If memory tagging is disabled in the current execution environment (see
+<<MEM_TAG_EN>>) or MTAG=1 (see <<TAGGED_PAGE>>) in the page table entry for
+code page, then `gentag` instruction falls back to zimop behavior and zeroes
+destination register.
+
 [wavedrom, ,svg]
 ....
 {reg: [
@@ -82,15 +87,17 @@ See Appendix for example how this can be used by codegen.
 
 ==== Arithmetics on pointer tag - addtag rd, rs1, #tag_imm4
 
-`addtag rd, rs1` is a pseudo for `gentag rd, rs1` with tag_imm4 != 0. If memory
-tagging is enabled in the current execution environment (see <<MEM_TAG_EN>>),
-`addtag rd, rs1` instruction performs addition of `pointer_tag` specified in
-`rs1[XLEN:XLEN-pointer_tag_width+1]` with the unsigned value `tag_imm4` shifted
-left by `XLEN - pointer_tag_width` bits and places incremented `pointer_tag`
-value in `rd[XLEN:XLEN-pointer_tag_width+1]`.
-If memory tagging is disabled in the current execution environment,
-then `addtag` instruction falls back to zimop behavior
-and zeroes destination register.
+If memory tagging is enabled in the current execution environment (see
+<<MEM_TAG_EN>>) and code page has `MTAG` bit clear in the page table entry
+(see <<TAGGED_PAGE>>), `addtag rd, rs1` instruction performs addition of
+`pointer_tag` specified in `rs1[XLEN:XLEN-pointer_tag_width+1]` with the
+unsigned value `tag_imm4` shifted left by `XLEN - pointer_tag_width` bits and
+places incremented `pointer_tag` value in `rd[XLEN:XLEN-pointer_tag_width+1]`.
+
+If memory tagging is disabled in the current execution environment (see
+<<MEM_TAG_EN>>) or MTAG=1 (see <<TAGGED_PAGE>>) in the page table entry for
+code page, then `addtag` instruction falls back to zimop behavior and zeroes
+destination register.
 
 [wavedrom, ,svg]
 ....
@@ -127,9 +134,6 @@ immediate (#chunk_count) in the instruction. This instruction is encoded using
 `MOP.RR.0` from zimop extension. Immediate encodings in #chunk_count are zero
 based and thus #chunk_count = 0 means first chunk and #chunk_count = 15 means
 16th chunk.
-If memory tagging is disabled in the current execution environment,
-then `settag` instruction falls back to zimop behavior
-and zeroes x0, which is a no-op.
 
 [NOTE]
 ====
@@ -146,10 +150,16 @@ required by software, it can be added.
 ==== Store tag(s) for memory chunk(s): settag rs1, #chunk_count
 
 If memory tagging is enabled in the current execution environment (see
-<<MEM_TAG_EN>>), `settag` instruction creates a `mc_tag` =
+<<MEM_TAG_EN>>) and code page has `MTAG` bit clear in the page table entry
+(see <<TAGGED_PAGE>>), `settag` instruction creates a `mc_tag` =
 `rs1[XLEN:XLEN-pointer_tag_width+1]` and stores `mc_tag(s)` for consecutive
 memory chunks encoded by `chunk_count` starting with the first memory chunk
 calculated from virtual address specified in `rs1`.
+
+If memory tagging is disabled in the current execution environment (see
+<<MEM_TAG_EN>>) or MTAG=1 (see <<TAGGED_PAGE>>) in the page table entry for
+code page, then `settag` instruction falls back to zimop behavior and zeroes
+x0, which is a no-op.
 
 [wavedrom, ,svg]
 ....


### PR DESCRIPTION
gentag doesnt need rs1 parameter. Forcing it to be x0.

MTE instructions should fallback to zimop behavior if fetched from code page if
MTAG=1.