### PR TITLE
src/mte*: change Zimte to Zimt

### DIFF
--- a/src/mte_intro.adoc
+++ b/src/mte_intro.adoc
@@ -86,7 +86,7 @@ fuzzing) environments. Hardware assistance in management and checking of `tags`
 on memory accesses helps in more scalable testing of software in variety of
 deployment scenarios including production.
 
-Leveraging this software usage model, the `Zimte` extension defines a mechanism
+Leveraging this software usage model, the `Zimt` extension defines a mechanism
 for tagged pointer construction, tag management instructions to store tags and
 tag checks on memory accesses (pointer dereferences). `Svatag` and `Smvatag`
 extensions defines tag storage mechanism in virtual memory along with protection

--- a/src/mte_tag.adoc
+++ b/src/mte_tag.adoc
@@ -1,7 +1,7 @@
 [[tagging]]
-== Memory tagging extension (Zimte)
+== Memory tagging extension (Zimt)
 
-The Zimte extension divides address space of the program in equal memory chunks
+The Zimt extension divides address space of the program in equal memory chunks
 of 16 bytes (hereafter `mc`). Each `mc` in address space can be associated with
 a tag (hereafter `mc_tag`) by software and `mc_tag` for `mc` is stored in
 memory defined by extension Svatag (see <<virtualtag>>).
@@ -9,7 +9,7 @@ memory defined by extension Svatag (see <<virtualtag>>).
 Software (runtime memory allocator or compiler) that constructs pointers to
 access memory (and thus memory chunks) is expected to place a tag (hereafter
 `pointer_tag`) in high unused bits of the pointer as defined by the pointer
-masking extensions cite:[PMASKING]. Thus `Zimte` depends on the pointer masking
+masking extensions cite:[PMASKING]. Thus `Zimt` depends on the pointer masking
 extension and is applicable to only for XLEN=64. Pointer masking has to be
 enabled as a requirement for memory tagging to be enabled in the execution
 environment.
@@ -21,7 +21,7 @@ encoding and thus make memory tagging extension dependent on zimop.
 
 === Taxonomy for loads and stores
 
-`Zimte` introduces new type of loads and stores to the hart and enforces tag
+`Zimt` introduces new type of loads and stores to the hart and enforces tag
 checks on certain loads and stores. Following terminologies are defined for
 better clarity and will be used in the rest of the specification.
 
@@ -69,7 +69,7 @@ describes valid configurations of `pointer_tag_width` and `mc_tag_width`.
 
 === Tag placement in pointer
 
-Zimte defines following instructions to annotate a pointer with `pointer_tag`
+Zimt defines following instructions to annotate a pointer with `pointer_tag`
 and perform arithmetics on `pointer_tag` in a tagged pointer. Placement and
 arithmetics on `pointer_tag` are performed in-place in masked bits (as defined
 by pointer masking extension) starting at b63. Instructions introduced to
@@ -154,7 +154,7 @@ See Appendix for example how this can be used by codegen.
 [[TAG_STORE]]
 === set tag(s) for memory chunk(s)
 
-Zimte defines an instruction to store tag (i.e. `pointer_tag`) value(s) for
+Zimt defines an instruction to store tag (i.e. `pointer_tag`) value(s) for
 consecutive 1 to 16 memory chunk(s). Base address of the first memory chunk is
 calculated by doing `rs1 & (~0xF)`. Count of memory chunk is encoded as 4 bit
 immediate (#chunk_count) in the instruction. This instruction is encoded using
@@ -298,7 +298,7 @@ synchronously.
 [[TAGGED_PAGE]]
 === Tag checks on page basis
 
-`Zimte` introduces `memory tag` (`MTAG`) bit in first stage page table which if
+`Zimt` introduces `memory tag` (`MTAG`) bit in first stage page table which if
 set in page table entry and memory tagging is enabled from *envcfg CSR,
 following rules apply:
 
@@ -339,7 +339,7 @@ kept as reserved for such page table encodings.
 In M-mode, enable for memory tagging is controlled via `mseccfg` CSR.
 
 Enablement for privilege modes less than M-mode is controlled through
-`__x__envcfg` CSR. Zimte adds two bits termed as `MTE_MODE` to `__x__envcfg`
+`__x__envcfg` CSR. Zimt adds two bits termed as `MTE_MODE` to `__x__envcfg`
 CSR which controls enabling of memory tagging and `pointer_tag_width` for the
 next privilege mode. A `MT_ASYNC` bit (bit 36) is added to `__x__envcfg` CSR
 and if set, software check exceptions due to tag mismatches on store operations
@@ -394,13 +394,13 @@ configuration
 ], config:{lanes: 4, hspace:1024}}
 ....
 
-The Zimte extension adds the `MTE_MODE` field (bit 35:34) to `mseccfg`. When the
+The Zimt extension adds the `MTE_MODE` field (bit 35:34) to `mseccfg`. When the
 `MTE_MODE` field is set to `0b10` or `0b11`, memory tagging is enabled for
 M-mode.
 
 When `MTE_MODE` is `0b00`, the following rules apply to M-mode:
 
-* Zimte instructions will revert to their behavior as defined by Zimop.
+* Zimt instructions will revert to their behavior as defined by Zimop.
 
 ==== Machine Environment Configuration Register (`menvcfg`)
 
@@ -426,13 +426,13 @@ When `MTE_MODE` is `0b00`, the following rules apply to M-mode:
 ], config:{lanes: 4, hspace:1024}}
 ....
 
-The Zimte extension adds the `MTE_MODE` field (bit 35:34) to `menvcfg`. When the
+The Zimt extension adds the `MTE_MODE` field (bit 35:34) to `menvcfg`. When the
 `MTE_MODE` field is set to `0b10` or `0b11`, memory tagging is enabled for
 HS/S-mode.
 
 When `MTE_MODE` is `0b00`, the following rules apply to HS/S-mode:
 
-* Zimte instructions will revert to their behavior as defined by Zimop.
+* Zimt instructions will revert to their behavior as defined by Zimop.
 
 ==== Supervisor Environment Configuration Register (`senvcfg`)
 
@@ -454,13 +454,13 @@ When `MTE_MODE` is `0b00`, the following rules apply to HS/S-mode:
 ], config:{lanes: 4, hspace:1024}}
 ....
 
-The Zimte extension adds the `MTE_MODE` field (bit 35:34) to `senvcfg`. When the
+The Zimt extension adds the `MTE_MODE` field (bit 35:34) to `senvcfg`. When the
 `MTE_MODE` field is set to `0b10` or `0b11`, memory tagging is enabled for
 VU/U-mode.
 
 When `MTE_MODE` is `0b00`, the following rules apply to VU/U-mode:
 
-* Zimte instructions will revert to their behavior as defined by Zimop.
+* Zimt instructions will revert to their behavior as defined by Zimop.
 
 ==== Hypervisor Environment Configuration Register (`henvcfg`)
 
@@ -486,13 +486,13 @@ When `MTE_MODE` is `0b00`, the following rules apply to VU/U-mode:
 ], config:{lanes: 4, hspace:1024}}
 ....
 
-The Zimte extension adds the `MTE_MODE` field (bit 35:34) to `henvcfg`. When the
+The Zimt extension adds the `MTE_MODE` field (bit 35:34) to `henvcfg`. When the
 `MTE_MODE` field is set to `0b10` or `0b11`, memory tagging is enabled for
 VS-mode.
 
 When `MTE_MODE` is `0b00`, the following rules apply to VS-mode:
 
-* Zimte instructions will revert to their behavior as defined by Zimop.
+* Zimt instructions will revert to their behavior as defined by Zimop.
 
 <<<
 

--- a/src/mte_tagelide.adoc
+++ b/src/mte_tagelide.adoc
@@ -2,7 +2,7 @@
 == tag check elide extension
 
 `Zitagelide` is defined to aid software to elide tag checks on memory accesses
-on a tagged page, and is dependent on `Zimte`, `C` and `Zcmop` extensions.
+on a tagged page, and is dependent on `Zimt`, `C` and `Zcmop` extensions.
 
 Certain regular load or store can be elided for tag checks if software
 (compiler) can statically determine that they are safe to access. One such
@@ -17,7 +17,7 @@ check disable` (TTCD) state and is defined as below:
 * 1 - `TAG_CHECK_ELIDE` - If memory tagging is enabled, tag checks elided.
 
 `Zitagelide` defines a new instruction `nietc` short for next instruction elide
-tag check(s). Encoding for `nietc` is taken from `C.MOP.3`, thus making `Zimte`
+tag check(s). Encoding for `nietc` is taken from `C.MOP.3`, thus making `Zimt`
 dependent on `C` and `Zcmop` extensions. If memory tagging is enabled, then
 instruction `nietc` sets `TTCD` to `TAG_CHECK_ELIDE` state. A subsequent
 regular memory load or store clears `TTCD` to `TAG_CHECK_ENFORCED`. Thus any
@@ -83,7 +83,7 @@ in *status register is defined as below.
 ], config:{lanes: 4, hspace:1024}}
 ....
 
-The Zimte extension introduces the `SPTTCD` (bit 24) and `MPTTCD` (bit 42)
+The Zimt extension introduces the `SPTTCD` (bit 24) and `MPTTCD` (bit 42)
 fields that hold the previous `TTCD`. The `__x__PTTCD` fields are encoded as
 follows:
 
@@ -123,7 +123,7 @@ is cleared.
 ], config:{lanes: 4, hspace:1024}}
 ....
 
-Access to the `SPTTCD` field introduced by Zimte accesses the homonymous
+Access to the `SPTTCD` field introduced by Zimt accesses the homonymous
 fields of `mstatus` when `V=0` and the homonymous fields of `vsstatus`
 when `V=1`.
 
@@ -159,7 +159,7 @@ On a sret, SPTTCD is restored into hart's `TTCD` and SPTTCD is cleared.
 ], config:{lanes: 4, hspace:1024}}
 ....
 
-The Zimte extension introduces the `SPTTCD` (bit 24) field that hold the
+The Zimt extension introduces the `SPTTCD` (bit 24) field that hold the
 previous `TTCD`. The SPTTCD fields is encoded as follows:
 
 * 0 - `TAG_CHECK_ENFORCED` - If memory tagging is enabled, tag checks enforced.

--- a/src/mte_vatag.adoc
+++ b/src/mte_vatag.adoc
@@ -2,7 +2,7 @@
 == Virtually indexed tag storage (Svatag and Smvatag)
 
 Svatag (for S/HS/VS/U/VU) and Smvatag (for M) extensions defines that tag
-storage and tag lookups for memory chunks (`mc`) as defined by Zimte (see
+storage and tag lookups for memory chunks (`mc`) as defined by Zimt (see
 <<tagging>>) extension is in virtual address space of execution environment.
 Tag storage can be viewed as a large array (hereafter referred to as
 virtually indexed tag table or VITT) of the tags (`mc_tag`) with each tag


### PR DESCRIPTION
Resolves this github issue.
https://github.com/riscv/riscv-memory-tagging/issues/58