### PR TITLE
Define addtag to copy the source register if MT is disabled

### DIFF
--- a/src/mte_tag.adoc
+++ b/src/mte_tag.adoc
@@ -166,7 +166,7 @@ has three different semantics depending on execution environment
 * MT is enabled in the current execution environment: the tag addition is
   performed.
 
-Because that menas `rd` always contains a valid pointer if MT is implemented,
+That means `rd` always contains a valid pointer if MT is implemented,
 this allows improved codegen if the target is known to implement MT. See
 "Example: optimized stack tagging codegen" in Appendix.
 =====

--- a/src/mte_tag.adoc
+++ b/src/mte_tag.adoc
@@ -713,7 +713,7 @@ for trapping instruction is deposited in `hstatus.MTAG_I`.
 
 ==== Example: optimized stack tagging codegen
 
-If we know we are compiling for a target that implements Zimt, we can
+Software that targets implementations which support Zimt can
 optimize the stack codegen to skip `or` when constructing pointers to
 objects.
 

--- a/src/mte_tag.adoc
+++ b/src/mte_tag.adoc
@@ -161,7 +161,7 @@ If memory tagging is disabled in the current execution environment (see
 has three different semantics depending on execution environment
 
 * MT is not implemented: `rd` is zeroed;
-* MT is implemented by disabled in the current execution environment: `rs1`
+* MT is implemented but disabled in the current execution environment: `rs1`
   is copied into `rd`;
 * MT is enabled in the current execution environment: the tag addition is
   performed.

--- a/src/mte_tag.adoc
+++ b/src/mte_tag.adoc
@@ -139,8 +139,8 @@ unsigned value `tag_imm4` shifted left by `XLEN - pointer_tag_width` bits and
 places incremented `pointer_tag` value in `rd[XLEN:XLEN-pointer_tag_width+1]`.
 
 If memory tagging is disabled in the current execution environment (see
-<<MEM_TAG_EN>>), then `addtag` instruction falls back to zimop behavior and
-zeroes destination register.
+<<MEM_TAG_EN>>), then `addtag` instruction copies `rs1` into `rd.
+
 
 [wavedrom, ,svg]
 ....
@@ -154,6 +154,22 @@ zeroes destination register.
   {bits:  7, name: '1000011', attr:['addtag']},
 ], config:{lanes: 1, hspace:1024}}
 ....
+
+[NOTE]
+=====
+`addtag`, unlike the other instructions that are taken from Zimops codepoints,
+has three different semantics depending on execution environment
+
+* MT is not implemented: `rd` is zeroed;
+* MT is implemented by disabled in the current execution environment: `rs1`
+  is copied into `rd`;
+* MT is enabled in the current execution environment: the tag addition is
+  performed.
+
+Because that menas `rd` always contains a valid pointer if MT is implemented,
+this allows improved codegen if the target is known to implement MT. See
+"Example: optimized stack tagging codegen" in Appendix.
+=====
 
 [NOTE]
 =====
@@ -686,6 +702,36 @@ for trapping instruction is deposited in `hstatus.MTAG_I`.
         addi s2, sp, 32
         addtag t1, t0, 2  # tag_imm4 = 2
         or s2, s2, t1
+         :
+        # scope of second object starts, tag
+        settag s2, 1
+        # [...] do things with s2 while in scope
+        # scope of second object ends, tag back to zero
+        addi s2, sp, 32
+        settag s2, 1
+-----
+
+==== Example: optimized stack tagging codegen
+
+If we know we are compiling for a target that implements Zimt, we can
+optimize the stack codegen to skip `or` when constructing pointers to
+objects.
+
+[listing]
+-----
+    function:
+        # N.B. sp remains untagged at all times
+        addi sp, sp, -512 # stack frame size of 512 bytes
+        gentag t0   # generate a pointer_tag in high bits of t0
+        or t0, sp, t0
+         :
+        # first object is tagged <random tag> + 1
+        addi s1, t0, 16
+        addtag s1, s1, 1  # tag_imm4 = 1
+         :
+        # second object is tagged <random tag> + 2
+        addi s2, t0, 32
+        addtag s2, s2, 2  # tag_imm4 = 2
          :
         # scope of second object starts, tag
         settag s2, 1

--- a/src/mte_tag.adoc
+++ b/src/mte_tag.adoc
@@ -139,7 +139,7 @@ unsigned value `tag_imm4` shifted left by `XLEN - pointer_tag_width` bits and
 places incremented `pointer_tag` value in `rd[XLEN:XLEN-pointer_tag_width+1]`.
 
 If memory tagging is disabled in the current execution environment (see
-<<MEM_TAG_EN>>), then `addtag` instruction copies `rs1` into `rd.
+<<MEM_TAG_EN>>), then `addtag` instruction moves `rs1` into `rd.
 
 
 [wavedrom, ,svg]


### PR DESCRIPTION
This allows more optimized codegen for when the target is known to implement MT.

Fixes https://github.com/riscv/riscv-memory-tagging/issues/96