### PR TITLE
mte_vatag: add stateen interaction

### DIFF
--- a/src/mte_tag.adoc
+++ b/src/mte_tag.adoc
@@ -618,11 +618,11 @@ When the active `pointer_tag_width = 4`, bits `[127:16]` are ignored by
 ===== Accessibility of Zimt CSRs
 CSR access to `senvmtagexclude0`, `senvmtagexclude1`, `henvmtagexclude0`, and
 `henvmtagexclude1` from modes less privileged than M causes illegal instruction
-exception if Smstateen is implemented and `mstateen0.MTE=0`.
+exception if Smstateen is implemented and `mstateen0.MT=0`.
 
 CSR access to `senvmtagexclude0`, and `senvmtagexclude1` from VS mode causes
-virtual instruction exception if Ssstateen is implemented, `hstateen0.MTE=0`,
-and `mstateen0.MTE=1` or Smstateen is not implemented.
+virtual instruction exception if Ssstateen is implemented, `hstateen0.MT=0`,
+and `mstateen0.MT=1` or Smstateen is not implemented.
 
 ==== Machine Security Configuration Register(`mseccfg`)
 

--- a/src/mte_tag.adoc
+++ b/src/mte_tag.adoc
@@ -614,6 +614,16 @@ When the active `pointer_tag_width = 4`, bits `[127:16]` are ignored by
 | `[15:0]` or `[127:0]`
 |===
 
+[[TAG_EXCLUSION_CSR_ACCESSIBILITY]]
+===== Accessibility of Zimt CSRs
+CSR access to `senvmtagexclude0`, `senvmtagexclude1`, `henvmtagexclude0`, and
+`henvmtagexclude1` from modes less privileged than M causes illegal instruction
+exception if Smstateen is implemented and `mstateen0.MTE=0`.
+
+CSR access to `senvmtagexclude0`, and `senvmtagexclude1` from VS mode causes
+virtual instruction exception if Ssstateen is implemented, `hstateen0.MTE=0`,
+and `mstateen0.MTE=1` or Smstateen is not implemented.
+
 ==== Machine Security Configuration Register(`mseccfg`)
 
 .Machine security configuration register(`mseccfg`)

--- a/src/mte_vatag.adoc
+++ b/src/mte_vatag.adoc
@@ -87,16 +87,16 @@ privileged CSRs.
 ==== Accessibility of Svatag CSRs
 CSR access to `svittu`, `svitts`, `vsvitts`, and `vsvittu` from modes less
 privileged than M causes illegal instruction exception if Smstateen is
-implemented and `mstateen0.MTE=0`.
+implemented and `mstateen0.MT=0`.
 
 CSR access to `svitts` and `svittu` from VS mode causes virtual instruction
-exception if Ssstateen is implemented, `hstateen0.MTE=0`, and `mstateen0.MTE=1`
+exception if Ssstateen is implemented, `hstateen0.MT=0`, and `mstateen0.MT=1`
 or Smstateen is not implemented.
 
 NOTE: The CSR access from VS mode, if allowed, uses the state of `vsvitts` and
 `vsvittu` CSRs, respectively.
 
-WARNING: The position of the MTE bit in `[mh]stateen` must be specified before
+WARNING: The position of the MT bit in `[mh]stateen` must be specified before
 ratification.
 
 [[TAG_MEM_PROTECTION]]

--- a/src/mte_vatag.adoc
+++ b/src/mte_vatag.adoc
@@ -83,6 +83,22 @@ privileged CSRs.
 `Svatag` defines the `svittu`, `svitts`, `vsvittu`` and `vsvitts` CSRs while
 `Smvatag` defines `mvitt`.
 
+[[TAG_BASE_CSR_ACCESSIBILITY]]
+==== Accessibility of Svatag CSRs
+CSR access to `svittu`, `svitts`, `vsvitts`, and `vsvittu` from modes less
+privileged than M causes illegal instruction exception if Smstateen is
+implemented and `mstateen0.MTE=0`.
+
+CSR access to `svitts` and `svittu` from VS mode causes virtual instruction
+exception if Ssstateen is implemented, `hstateen0.MTE=0`, and `mstateen0.MTE=1`
+or Smstateen is not implemented.
+
+NOTE: The CSR access from VS mode, if allowed, uses the state of `vsvitts` and
+`vsvittu` CSRs, respectively.
+
+WARNING: The position of the MTE bit in `[mh]stateen` must be specified before
+ratification.
+
 [[TAG_MEM_PROTECTION]]
 === Protection of tag storage
 


### PR DESCRIPTION
Since the CSRs expose new architectural state that needs to be managed for lower privileges, we must make sure that they do not create unintentional communication channels.